### PR TITLE
Improve readme, allow prepend_path with filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,35 @@ From the Julia Pkg manager:
 
 ## Usage
 
-This package was designed with the intention to be used in `makedocs` in [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl). For example, if you have a folder of [Literate.jl](https://github.com/fredrikekre/Literate.jl) examples in `MyPkg/src/tutorials`, you can use `AutoPages.jl`'s `gather_pages` to create the nested array of `Pair`'s:
+This package was designed to provide automation tools for the `pages` keyword in [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl)'s `makedocs` method. Our [Tutorials](https://charleskawczynski.github.io/AutoPages.jl/dev/tutorials/home/) are collected with this package, which was configured to be an example itself:
 
 ```julia
-using AutoPages: gather_pages
+using Documenter
+using AutoPages
+using AutoPages: gather_pages, replace_reverse
 
+tutorials_dir = joinpath(@__DIR__, "..", "tutorials") # tutorials directory
+mkpath(tutorials_dir)
 tutorials, tutorials_list = gather_pages(;
-  directory=joinpath(@__DIR__, "..", "tutorials"),
+  directory=tutorials_dir,
   extension_filter=x->endswith(x, ".jl"),
+  transform_extension=x->replace_reverse(x, ".jl" => ".md"; count=1),
   remove_first_level=true)
 
 makedocs(
     sitename = "AutoPages",
-    format = format,
+    format = Documenter.HTML(
+        prettyurls = get(ENV, "CI", nothing) == "true",
+        collapselevel = 1,
+        ),
     clean = true,
     modules = [Documenter, AutoPages],
     pages = Any["Home" => "index.md",
                 "Tutorials" => tutorials],
+)
+
+deploydocs(
+    repo = "github.com/charleskawczynski/AutoPages.jl.git",
+    target = "build",
 )
 ```

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,17 +10,17 @@ tutorials, tutorials_list = gather_pages(;
   transform_extension=x->replace_reverse(x, ".jl" => ".md"; count=1),
   remove_first_level=true)
 
-#### Let's suppose we've used Literate to generate markdown:
-for tutorial in tutorials_list
-    mkpath(joinpath(@__DIR__,"src",dirname(tutorial)))
-end
-for tutorial in tutorials_list
-    title = transform_file(basename(tutorial))
-    open(joinpath(@__DIR__,"src",tutorial), "w") do io
-    print(io, "# $(title)")
-    end
-end
-####
+# #### Let's suppose we've used Literate to generate markdown:
+# for tutorial in tutorials_list
+#     mkpath(joinpath(@__DIR__,"src",dirname(tutorial)))
+# end
+# for tutorial in tutorials_list
+#     title = transform_file(basename(tutorial))
+#     open(joinpath(@__DIR__,"src",tutorial), "w") do io
+#     print(io, "# $(title)")
+#     end
+# end
+# ####
 
 format = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true",

--- a/src/AutoPages.jl
+++ b/src/AutoPages.jl
@@ -149,13 +149,12 @@ function gather_pages(;
       filenames = [String(joinpath(r, f)) for (r, _, files) in Base.Filesystem.walkdir(directory) for f in files]
       filenames = filter(extension_filter, filenames)
       filenames = map(x -> String(last(split(x, dirname(directory)))), filenames)
-      filenames = map(x -> String(lstrip(x, path_separator)), filenames)
-      filenames = map(x -> joinpath(prepend_path, x), filenames)
     end
 
     filenames = map(x -> transform_extension(x), filenames)
     filter!(x -> !(x == path_separator), filenames)
     filenames = map(x -> String(lstrip(x, path_separator)), filenames)
+    filenames = map(x -> joinpath(prepend_path, x), filenames)
     dirnames = collect(Set(dirname.(filenames)))
 
     # TODO: Might be able to improve performance here


### PR DESCRIPTION
 - Allows `prepend_path` to be used with `filenames`
 - Improve readme.md
 - Comment generation of docs markdown